### PR TITLE
Fix #5 modified ore stack sizes.

### DIFF
--- a/DeepMineMod/DeepMineMod.csproj
+++ b/DeepMineMod/DeepMineMod.csproj
@@ -28,6 +28,9 @@
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>Libs\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
+    <Reference Include="com.unity.multiplayer-hlapi.Runtime">
+      <HintPath>Libs\com.unity.multiplayer-hlapi.Runtime.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/DeepMineMod/Patches.cs
+++ b/DeepMineMod/Patches.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using Assets.Scripts.Objects.Items;
 using Assets.Scripts.GridSystem;
 using Assets.Scripts.Objects.Electrical;
+using Assets.Scripts.Objects;
 
 namespace DeepMineMod
 {
@@ -53,15 +54,18 @@ namespace DeepMineMod
     }
 
     /// <summary>
-    /// Alter ore drop quantities based on their world position
+    /// Alter ore max stack size
     /// </summary>
-    [HarmonyPatch(typeof(Ore), "Start")]
-    public class Ore_Start
+    [HarmonyPatch(typeof(Thing), "LoadPrefabs")]
+    public class Thing_LoadPrefabs
     {
-        static void Postfix(Ore __instance)
+        static void Postfix()
         {
-            __instance.MaxQuantity = DeepMinePlugin.OreStackSize;
+            foreach (var orePrefab in Ore.AllOrePrefabs) {
+                orePrefab.MaxQuantity = DeepMinePlugin.OreStackSize;
+            }
         }
+
     }
 
     /// <summary>


### PR DESCRIPTION
Fix #5. The prefab has the MaxQuantity embedded, which is used by Stackable.SplitStack
to clamp the stack whenever a new stack is created before Ore.Start is called.
This fixes stacks larger than 100 from having ore disappear when split in half.